### PR TITLE
Proc.newにブロックをつけた

### DIFF
--- a/mikutwitter/cache.rb
+++ b/mikutwitter/cache.rb
@@ -7,12 +7,12 @@ require 'digest/md5'
 module MikuTwitter::Cache
   CACHE_EXPIRE = 60 * 60 * 24 * 2
 
-  def cache(api, url, options, method)
+  def cache(api, url, options, method, &proc)
     if :get == method and options[:cache]
       if(:keep == options[:cache])
-        _cache_keep(api, url, options, method, &Proc.new)
+        _cache_keep(api, url, options, method, &proc)
       else
-        _cache_get(api, url, options, method, &Proc.new) end
+        _cache_get(api, url, options, method, &proc) end
     else
       yield end end
 

--- a/mikutwitter/query.rb
+++ b/mikutwitter/query.rb
@@ -24,10 +24,10 @@ module MikuTwitter::Query
     super(*a, &b) end
 
   # 同じURLに対して同時にリクエストを送らないように、APIのURL毎にユニークなロックを取得する
-  def self.api_lock(url)
+  def self.api_lock(url, &proc)
     result = Lock.synchronize{
       @url_lock ||= Hash.new{ |h, k| h[k] = Monitor.new }
-      @url_lock[url] }.synchronize(&Proc.new)
+      @url_lock[url] }.synchronize(&proc)
     @url_lock.delete(url)
     result end
 


### PR DESCRIPTION
Ruby2.7からブロックなしのProcはdeprecatedになったため
( mikutter/twitter#1 )