### PR TITLE
既知のWorldにおいてaccount/verify_credentialsを2回以上呼び出さないようにした

### DIFF
--- a/model/world.rb
+++ b/model/world.rb
@@ -207,9 +207,13 @@ module Plugin::Twitter
     private
 
     def user_initialize
+      notice 'Plugin::Twitter::World#user_initialize'
       if self[:user]
         self[:user] = Plugin::Twitter::User.new_ifnecessary(self[:user])
-        (twitter/:account/:verify_credentials).user.next(&method(:user_data_received)).trap(&method(:user_data_failed)).terminate
+        run_once(self[:user]) { (twitter/:account/:verify_credentials).user }
+          .next(&method(:user_data_received))
+          .trap(&method(:user_data_failed))
+          .terminate
       else
         res = twitter.query!('account/verify_credentials', cache: true)
         if "200" == res.code
@@ -221,11 +225,17 @@ module Plugin::Twitter
     end
 
     def user_data_received(user)
-      self[:user] = user
-      Plugin.call(:world_modify, self)
+      notice 'Plugin::Twitter::World#user_data_received'
+      # user_initializeはrun_onceでUser ID毎に結果がキャッシュされ、起動後2回目以降の正常系では同じオブジェクトがここに来る。
+      # その時は処理がループしてしまうので、Worldを更新しない。
+      unless self[:user].equal?(user)
+        self[:user] = user
+        Plugin.call(:world_modify, self)
+      end
     end
 
     def user_data_failed(exception)
+      notice 'Plugin::Twitter::World#user_data_failed'
       case exception
       when MikuTwitter::Error
         if not UserConfig[:verify_credentials]
@@ -247,6 +257,19 @@ module Plugin::Twitter
                         "Twitterサーバの情況を調べる→ https://dev.twitter.com/status\n"+
                         "Twitterサーバの情況を調べたくない→ http://ex.nicovideo.jp/vocaloid\n\n--\n\n" +
                         "#{res.code} #{res.body}"
+      end
+    end
+
+    # userごとに一度だけブロックを評価し、deferredを返す。
+    # 2回目以降はブロックの評価はせず、最初の呼び出しと実行結果を共有するdeferredを生成して返す。
+    def run_once(user, &block)
+      @@run_once_mutex ||= Mutex.new
+      @@run_once_deferred_by_userid ||= {}
+      @@run_once_mutex.synchronize do
+        trunk = @@run_once_deferred_by_userid[user.id] || block.call
+        branch = @@run_once_deferred_by_userid[user.id] = Delayer::Deferred.new(true)
+        trunk.next { |v| branch.call(v); v }
+          .trap { |v| branch.fail(v); Delayer::Deferred.fail(v) }
       end
     end
   end

--- a/model/world.rb
+++ b/model/world.rb
@@ -207,7 +207,6 @@ module Plugin::Twitter
     private
 
     def user_initialize
-      notice 'Plugin::Twitter::World#user_initialize'
       if self[:user]
         self[:user] = Plugin::Twitter::User.new_ifnecessary(self[:user])
         run_once(self[:user]) { (twitter/:account/:verify_credentials).user }
@@ -225,7 +224,6 @@ module Plugin::Twitter
     end
 
     def user_data_received(user)
-      notice 'Plugin::Twitter::World#user_data_received'
       # user_initializeはrun_onceでUser ID毎に結果がキャッシュされ、起動後2回目以降の正常系では同じオブジェクトがここに来る。
       # その時は処理がループしてしまうので、Worldを更新しない。
       unless self[:user].equal?(user)
@@ -235,7 +233,6 @@ module Plugin::Twitter
     end
 
     def user_data_failed(exception)
-      notice 'Plugin::Twitter::World#user_data_failed'
       case exception
       when MikuTwitter::Error
         if not UserConfig[:verify_credentials]


### PR DESCRIPTION
fix #5 

Plugin::Twitter::World#user_initialize で呼び出している `account/verify_credentials.json` を、1Worldにつき1回だけ呼び出すようにします。また、処理の成否と結果のオブジェクトは共有するようにします。

これにより、APIの呼び出しがキャッシュされ過剰に呼び出されないようになります。  
また、結果のオブジェクトが共有されることで object_id を当てにしたループチェックができるようになりました。これによって、際限無くWorldの更新が走らないようになりました。